### PR TITLE
#2 - adding version-specific symlink to java home

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,7 +108,12 @@ class jdk_oracle(
                 target  => '/etc/alternatives/javac',
                 require => File['/etc/alternatives/javac'],
             }
-            file { '/opt/java_home':
+            file { "${install_dir}/java_home":
+                ensure  => link,
+                target  => $java_home,
+                require => Exec['extract_jdk'],
+            }
+            file { "${install_dir}/jdk-${version}":
                 ensure  => link,
                 target  => $java_home,
                 require => Exec['extract_jdk'],

--- a/spec/classes/jdk_oracle_init_spec.rb
+++ b/spec/classes/jdk_oracle_init_spec.rb
@@ -19,6 +19,9 @@ describe 'jdk_oracle', :type => 'class' do
                     :ensure  => 'link',
                     :target  => '/opt/jdk1.7.0/bin/java',
                 })
+                should contain_file('/opt/jdk-7').with({
+                    :ensure  => 'link',
+                })
             }
         end
 
@@ -30,6 +33,9 @@ describe 'jdk_oracle', :type => 'class' do
             it {
                 should contain_file('/opt/jdk-6u45-linux-x64.bin')
                 should contain_exec('extract_jdk').with_creates('/opt/jdk1.6.0_45')
+                should contain_file('/opt/jdk-6').with({
+                    :ensure  => 'link',
+                })
             }
         end
 


### PR DESCRIPTION
- Fixed hard-coded issue with existing symlink
- Added symlink for jdk-VERSION
