### PR TITLE
Updated Java download parameters for jdk6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,7 @@ class jdk_oracle(
             $java_home = "${install_dir}/jdk1.7.0"
         }
         '6': {
-            $javaDownloadURI = "https://edelivery.oracle.com/otn-pub/java/jdk/6u45-b06/jdk-6u45-linux-x64.bin"
+            $javaDownloadURI = "https://edelivery.oracle.com/otn-pub/java/jdk/6u45-b06/jdk-6u45-linux-${plat_filename}.bin"
             $java_home = "${install_dir}/jdk1.6.0_45"
         }
         default: {


### PR DESCRIPTION
Oracle has changed its download policies, this change provides the latest workarounds to facilitate automated download of jdk6.
