### PR TITLE
Added package def for wget.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,9 @@ class jdk_oracle(
                 mode    => '0755',
                 require => Exec['get_jdk_installer'],
             }
+            package { 'wget':
+              ensure => present,
+            }
         }
 
         # Java 7/8 comes in a tarball so just extract it.


### PR DESCRIPTION
I was running into the same error as listed in this fork
https://github.com/schrepfler/puppet-jdk_oracle/issues/1

Followed the suggestion of adding
package { 'wget':
  ensure => present,
}

I am using this module to install JDK 7 on Ubuntu 13.10.
