### PR TITLE
"Ensure installation directory is available""

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,10 +92,9 @@ class jdk_oracle(
                 require => Package['wget'],
             }
 
-	    file { "${install_dir}":
-	        ensure => "directory",
+            file { "${install_dir}":
+                ensure  => "directory",
             }
-            
             file { "${install_dir}/${installerFilename}":
                 mode    => '0755',
                 require => Exec['get_jdk_installer'],


### PR DESCRIPTION
To avoid  the below error and to ensure that installation directory is
available , it's possible that user can specify the directory that
doesn't exists and expect the module to create it when needed. This change
takes care of it. Tested the changes in Amazon Linux AMI release 2013.03  OS with installation directories /usr/java and /opt .

change from notrun to 0 failed: Working directory '/usr/java' does not exist
