### PR TITLE
Detect Debian variants better w/ selector & regex

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,9 +205,9 @@ class jdk_oracle(
       }
       Debian:  {
         #Accommodate variations in default install locations for some variants of Debian  
-        case $::lsbdistdescription {
-          'Ubuntu 14.04 LTS': { $path_to_updatealternatives_tool = '/usr/bin/update-alternatives' }
-          default: { $path_to_updatealternatives_tool = '/usr/sbin/update-alternatives' }
+        $path_to_updatealternatives_tool = $::lsbdistdescription ? {
+          /Ubuntu 14\.04.*/ => '/usr/bin/update-alternatives',
+          default           => '/usr/sbin/update-alternatives',
         }
         
         exec { "${path_to_updatealternatives_tool} --install /usr/bin/java java ${java_home}/bin/java 20000":


### PR DESCRIPTION
Changed the conditional to use a regular expression instead of a fixed string, because the lsbdistdescription fact may return different strings at different points in the 14.04 LTS life cycle as point updates are released e.g. a fully update system currently returns "Ubuntu 14.04.1 LTS" instead of the original "Ubuntu 14.04 LTS".  Also clarified the contributed code and made it more extensible by dropping the case syntax in favour of a selector syntax.
