### PR TITLE
Puppet 4 support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -183,7 +183,7 @@ class jdk_oracle(
 
     # Set links depending on osfamily or operating system fact
     case $::osfamily {
-      RedHat, Linux: {
+      'RedHat', 'Linux': {
         if ( $default_java ) {
           file { '/etc/alternatives/java':
             ensure  => link,
@@ -217,7 +217,7 @@ class jdk_oracle(
           require => Exec['extract_jdk'],
         }
       }
-      Debian:  {
+      'Debian':  {
         #Accommodate variations in default install locations for some variants of Debian
         $path_to_updatealternatives_tool = $::lsbdistdescription ? {
           /Ubuntu 14\.04.*/ => '/usr/bin/update-alternatives',
@@ -241,7 +241,7 @@ class jdk_oracle(
           }
         }
       }
-      Suse: {
+      'Suse': {
         if ( $default_java ) {
           class { 'jdk_oracle::suse' :
             version   => $version,
@@ -252,7 +252,7 @@ class jdk_oracle(
         }
       }
 
-      default:   { fail('Unsupported OS, implement me?') }
+      default:   { fail("Unsupported OS: ${::osfamily}.  Implement me?") }
     }
   }
 }


### PR DESCRIPTION
It appears that puppet 4 needs to compare strings with the `osfamily` fact.

Note I tried to update the travis.yml to test against puppet 4 also, but `rspec-hiera-puppet` is not supported any more and so has not been updated for puppet 4, so there's more work to be done there.

Note I have tested this change on puppet 4.0.0 on centos 6.4 only.