### PR TITLE
make sure to configure the specified java to be the "best" version

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -213,6 +213,10 @@ define jdk_oracle::install(
             require => Exec["extract_jdk_${version}"],
             unless  => "test $(/bin/readlink /etc/alternatives/jar) = '${java_home}/bin/jar'",
           }
+          exec { "${path_to_updatealternatives_tool} --install /usr/bin/jstack jstack ${java_home}/bin/jstack 20000":
+            require => Exec["extract_jdk_${version}"],
+            unless  => "test $(/bin/readlink /etc/alternatives/jstack) = '${java_home}/bin/jstack'",
+          }
           # activate new alternatives configuration (in case of a version change)
           exec { "${path_to_updatealternatives_tool} --set java ${java_home}/bin/java":
             require => Exec["${path_to_updatealternatives_tool} --install /usr/bin/java java ${java_home}/bin/java 20000"],
@@ -225,6 +229,10 @@ define jdk_oracle::install(
           exec { "${path_to_updatealternatives_tool} --set jar ${java_home}/bin/jar":
             require => Exec["${path_to_updatealternatives_tool} --install /usr/bin/jar jar ${java_home}/bin/jar 20000"],
             onlyif  => "test $(/bin/readlink /etc/alternatives/jar) != '${java_home}/bin/jar'",
+          }
+          exec { "${path_to_updatealternatives_tool} --set jstack ${java_home}/bin/jstack":
+            require => Exec["${path_to_updatealternatives_tool} --install /usr/bin/jstack jstack ${java_home}/bin/jstack 20000"],
+            onlyif  => "test $(/bin/readlink /etc/alternatives/jstack) != '${java_home}/bin/jstack'",
           }
           augeas { 'environment':
             context => '/files/etc/environment',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -200,6 +200,7 @@ define jdk_oracle::install(
         }
 
         if ( $default_java ) {
+          # create alternatives configuration for the specified version
           exec { "${path_to_updatealternatives_tool} --install /usr/bin/java java ${java_home}/bin/java 20000":
             require => Exec["extract_jdk_${version}"],
             unless  => "test $(readlink /etc/alternatives/java) = '${java_home}/bin/java'",
@@ -211,6 +212,19 @@ define jdk_oracle::install(
           exec { "${path_to_updatealternatives_tool} --install /usr/bin/jar jar ${java_home}/bin/jar 20000":
             require => Exec["extract_jdk_${version}"],
             unless  => "test $(/bin/readlink /etc/alternatives/jar) = '${java_home}/bin/jar'",
+          }
+          # activate new alternatives configuration (in case of a version change)
+          exec { "${path_to_updatealternatives_tool} --set java ${java_home}/bin/java":
+            require => Exec["${path_to_updatealternatives_tool} --install /usr/bin/java java ${java_home}/bin/java 20000"],
+            onlyif  => "test $(readlink /etc/alternatives/java) != '${java_home}/bin/java'",
+          }
+          exec { "${path_to_updatealternatives_tool} --set javac ${java_home}/bin/javac":
+            require => Exec["${path_to_updatealternatives_tool} --install /usr/bin/javac javac ${java_home}/bin/javac 20000"],
+            onlyif  => "test $(/bin/readlink /etc/alternatives/javac) != '${java_home}/bin/javac'",
+          }
+          exec { "${path_to_updatealternatives_tool} --set jar ${java_home}/bin/jar":
+            require => Exec["${path_to_updatealternatives_tool} --install /usr/bin/jar jar ${java_home}/bin/jar 20000"],
+            onlyif  => "test $(/bin/readlink /etc/alternatives/jar) != '${java_home}/bin/jar'",
           }
           augeas { 'environment':
             context => '/files/etc/environment',


### PR DESCRIPTION
On Ubuntu 14.04 I've updated from Oracle JDK 1.8.0_51-b16 to JDK 1.8.0_60-b27. I had `$default_java=true` set and thus was expecting the module would change the default Java to the new version. 

Apparently the module installed the new Java, but it failed to configure `update-alternatives` accordingly:

```
# update-alternatives --display java
java - manual mode
  link currently points to /data/jdk1.8.0_51/bin/java
/data/jdk1.8.0_51/bin/java - priority 20000
/data/jdk1.8.0_60/bin/java - priority 20000
Current 'best' version is '/data/jdk1.8.0_51/bin/java'.
```
As you can see, the "best" (and therefore symlinked) version is still 1.8.0_51-b16.

This PR addresses this and executes a `updates-alternatives --set` to actually activate the specified version.