### PR TITLE
The license identifier in metadata.json is invalid according to metadata-json-lint

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "1.4.0",
   "author": "tylerwalts",
   "summary": "Module for automating Oracle JDK download and installation",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/tylerwalts/puppet-jdk_oracle",
   "project_page": "https://github.com/tylerwalts/puppet-jdk_oracle",
   "issues_url": "https://github.com/tylerwalts/puppet-jdk_oracle/issues",


### PR DESCRIPTION
According to `metadata-json-lint`, the license identfier in metadata.json should be "`Apache-2.0`":

```bash
$ rake validate
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
metadata-json-lint metadata.json
Warning: License identifier Apache License, Version 2.0 is not in the SPDX list: http://spdx.org/licenses/
Errors found in metadata.json
rake aborted!
Command failed with status (1): [metadata-json-lint metadata.json...]
/var/lib/gems/1.9.1/gems/puppetlabs_spec_helper-0.10.3/lib/puppetlabs_spec_helper/rake_tasks.rb:251:in `block in <top (required)>'
/var/lib/gems/1.9.1/gems/puppetlabs_spec_helper-0.10.3/lib/puppetlabs_spec_helper/rake_tasks.rb:244:in `block in <top (required)>'
Tasks: TOP => metadata
(See full trace by running task with --trace)
```