### PR TITLE
Fix a typo in the instructions for installing with librarian-puppet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ mod "tylerwalts/jdk_oracle"
 
 From Source:
 ```
-    mod "jdk_oracle",
-        :git => "git://github.com/tylerwalts/puppet-jdk_oracle.git"
+mod "tylerwalts/jdk_oracle",
+    :git => "git://github.com/tylerwalts/puppet-jdk_oracle.git"
 ```
 
 


### PR DESCRIPTION
There's a small typo in the instructions for installing from source with librarian-puppet - using this method, the mod still needs to be called `"tylerwalts/jdk_oracle"`.