### PR TITLE
revert default values of $default_java and $create_symlink back to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ site.pp:
 *  jce
     * Boolean to optionally install Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files (Java 8 only)
 *  default_java
-    * Default to false. Boolean to indicate if the installed java version is linked as the default java, javac etc...
+    * Boolean to indicate if the installed java version is linked as the default java, javac etc. Defaults to true.
 *  ensure
     * Boolean to disable anything from happening (absent/removal not supported yet)
 *  download_url
@@ -137,9 +137,9 @@ Basicaly the same option as class jdk_oracle.
 *  jce
     * Boolean to optionally install Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files (Java 8 only)
 *  default_java
-    * Default to false. Boolean to indicate if the installed java version is linked as the default java, javac etc...
+    * Boolean to indicate if the installed java version is linked as the default java, javac etc. Defaults to true.
 *  create_symlink:
-    * default to false. Do we have to create a symlink of java_home to the default java_home
+    * Boolean to indicate if we have to create a symlink of java_home to the default java_home. Defaults to true.
 *  proxy
 
 ## Example Usage.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ class jdk_oracle (
   $platform       = hiera('jdk_oracle::platform',       'x64' ),
   $package        = hiera('jdk_oracle::package',        'jdk' ),
   $jce            = hiera('jdk_oracle::jce',            false ),
-  $default_java   = hiera('jdk_oracle::default_java',   false ),
+  $default_java   = hiera('jdk_oracle::default_java',   true ),
   $download_url   = hiera('jdk_oracle::download_url',   'http://download.oracle.com/otn-pub/java'),
   $proxy_host     = hiera('jdk_oracle::proxy_host',     false ),
   $ensure         = 'installed'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,8 +8,8 @@ define jdk_oracle::install(
   $platform       = 'x64',
   $package        = 'jdk',
   $jce            = false,
-  $default_java   = false,
-  $create_symlink = false,
+  $default_java   = true,
+  $create_symlink = true,
   $ensure         = 'installed',
 ) {
 


### PR DESCRIPTION
With PR #69 the default value of `$default_java` and `$create_symlink` was silently changed from `true` to `false`.  IMHO the old value of `true` makes total sense, as many people will want to use the downloaded Java as the new default.

There was no explanation provided for the change, so I consider it to be a mistake and suggest to revert back to the old default. This PR restores the old behaviour and updates the README accordingly.