### PR TITLE
restore augeas call to modify /etc/environment

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -205,6 +205,12 @@ define jdk_oracle::install(
             content => "export JAVA_HOME=${java_home}; PATH=\${PATH}:${java_home}/bin",
             require => Alternatives['java'],
           }
+          augeas { 'environment':
+            context => '/files/etc/environment',
+            changes => [
+              "set JAVA_HOME ${java_home}",
+            ],
+          }
           if ( $create_symlink ) {
             file { "${install_dir}/java_home":
               ensure  => link,


### PR DESCRIPTION
PR #69 _silently_ removed the augeas call to set `JAVA_HOME` in `/etc/environment`. I consider this a major flaw as it "breaks" Java updates (from a user perspective), because the old variable is no longer updated. Non-interactive logons don't seem to care for `/etc/profile.d/java.sh`, so this broke our Jenkins deployments.

No explanation for this change was provided, so my proposal is to restore the old behaviour.