### PR TITLE
Hash-Support for current Oracle 8-Download URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ site.pp:
     *  Java Version update to install
 * version_build
     *  Java Version build to install
+* version_hash
+    * The hash in more current Oracle download URLs
 *  install_dir
     *  Java Installation Directory
 *  use_cache
@@ -126,6 +128,8 @@ Basicaly the same option as class jdk_oracle.
     *  Java Version update to install
 * version_build
     *  Java Version build to install
+* version_hash
+    * The hash in more current Oracle download URLs
 *  install_dir
     *  Java Installation Directory
 *  use_cache

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,12 @@
 #   String.  Java Version build to install
 #   Defaults to <tt>Defaults based on major version</tt>.
 #
+# [*version_hash*]
+#   String. Hash from the Oracle download URL. Must be specified for more
+#   current Java versions. If set to an empty string, the hash is ignored
+#   in the URL. Defaults to an empty string, but if version_update or
+#   version_build are set to "default", the most current hash is used.
+#
 # [* java_install_dir *]
 #   String.  Java Installation Directory
 #   Defaults to <tt>/opt</tt>.
@@ -59,6 +65,7 @@ class jdk_oracle (
   $default_java   = hiera('jdk_oracle::default_java',   true ),
   $download_url   = hiera('jdk_oracle::download_url',   'http://download.oracle.com/otn-pub/java'),
   $proxy_host     = hiera('jdk_oracle::proxy_host',     false ),
+  $version_hash   = hiera('jdk_oracle::version_hash',   '' ),
   $ensure         = 'installed'
   ) {
 
@@ -73,6 +80,7 @@ class jdk_oracle (
     platform       => $platform,
     package        => $package,
     jce            => $jce,
+    version_hash   => $version_hash,
     default_java   => $default_java,
   }
   ensure_packages(['curl','unzip'], {'ensure' => 'present'})

--- a/manifests/suse.pp
+++ b/manifests/suse.pp
@@ -38,112 +38,112 @@ class jdk_oracle::suse {
     ensure  => link,
     target  => "${java_home_loc}/jre/lib/rt.jar",
     require => File[ $export_dir ],
-  } ->
-  file { "${export_dir}/jaas-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/jaas-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/jaas-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jaas.jar" :
+  }
+  -> file { "${export_dir}/jaas.jar" :
     ensure => link,
     target => "${export_dir}/jaas-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jce-${export_version}_Orac.jar" :
+  }
+  -> file { "${export_dir}/jce-${export_version}_Orac.jar" :
     ensure => link,
     target => "${java_home_loc}/jre/lib/jce.jar",
-  } ->
-  file { "${export_dir}/jce-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/jce-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/jce-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jce.jar" :
+  }
+  -> file { "${export_dir}/jce.jar" :
     ensure => link,
     target => "${export_dir}/jce-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jdbc-stdext-${export_version}_Orac.jar" :
+  }
+  -> file { "${export_dir}/jdbc-stdext-${export_version}_Orac.jar" :
     ensure => link,
     target => "${java_home_loc}/jre/lib/rt.jar",
-  } ->
-  file { "${export_dir}/jdbc-stdext-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/jdbc-stdext-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/jdbc-stdext-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jdbc-stdext-3.0.jar" :
+  }
+  -> file { "${export_dir}/jdbc-stdext-3.0.jar" :
     ensure => link,
     target => "${export_dir}/jdbc-stdext-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jdbc-stdext.jar" :
+  }
+  -> file { "${export_dir}/jdbc-stdext.jar" :
     ensure => link,
     target => "${export_dir}/jdbc-stdext-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jndi-${export_version}_Orac.jar" :
+  }
+  -> file { "${export_dir}/jndi-${export_version}_Orac.jar" :
     ensure => link,
     target => "${java_home_loc}/jre/lib/rt.jar",
-  } ->
-  file { "${export_dir}/jndi-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/jndi-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/jndi-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jndi.jar" :
+  }
+  -> file { "${export_dir}/jndi.jar" :
     ensure => link,
     target => "${export_dir}/jndi-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jndi-cos-${export_version}_Orac.jar" :
+  }
+  -> file { "${export_dir}/jndi-cos-${export_version}_Orac.jar" :
     ensure => link,
     target => "${java_home_loc}/jre/lib/rt.jar",
-  } ->
-  file { "${export_dir}/jndi-cos-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/jndi-cos-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/jndi-cos-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jndi-cos.jar" :
+  }
+  -> file { "${export_dir}/jndi-cos.jar" :
     ensure => link,
     target => "${export_dir}/jndi-cos-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jndi-ldap-${export_version}_Orac.jar" :
+  }
+  -> file { "${export_dir}/jndi-ldap-${export_version}_Orac.jar" :
     ensure => link,
     target => "${java_home_loc}/jre/lib/rt.jar",
-  } ->
-  file { "${export_dir}/jndi-ldap-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/jndi-ldap-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/jndi-ldap-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jndi-ldap.jar" :
+  }
+  -> file { "${export_dir}/jndi-ldap.jar" :
     ensure => link,
     target => "${export_dir}/jndi-ldap-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jndi-rmi-${export_version}_Orac.jar" :
+  }
+  -> file { "${export_dir}/jndi-rmi-${export_version}_Orac.jar" :
     ensure => link,
     target => "${java_home_loc}/jre/lib/rt.jar",
-  } ->
-  file { "${export_dir}/jndi-rmi-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/jndi-rmi-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/jndi-rmi-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jndi-rmi.jar" :
+  }
+  -> file { "${export_dir}/jndi-rmi.jar" :
     ensure => link,
     target => "${export_dir}/jndi-rmi-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jsse-${export_version}_Orac.jar" :
+  }
+  -> file { "${export_dir}/jsse-${export_version}_Orac.jar" :
     ensure => link,
     target => "${java_home_loc}/jre/lib/jsse.jar",
-  } ->
-  file { "${export_dir}/jsse-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/jsse-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/jsse-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/jsse.jar" :
+  }
+  -> file { "${export_dir}/jsse.jar" :
     ensure => link,
     target => "${export_dir}/jsse-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/sasl-${export_version}_Orac.jar" :
+  }
+  -> file { "${export_dir}/sasl-${export_version}_Orac.jar" :
     ensure => link,
     target => "${java_home_loc}/jre/lib/rt.jar",
-  } ->
-  file { "${export_dir}/sasl-${export_version}.jar" :
+  }
+  -> file { "${export_dir}/sasl-${export_version}.jar" :
     ensure => link,
     target => "${export_dir}/sasl-${export_version}_Orac.jar",
-  } ->
-  file { "${export_dir}/sasl.jar" :
+  }
+  -> file { "${export_dir}/sasl.jar" :
     ensure => link,
     target => "${export_dir}/sasl-${export_version}_Orac.jar",
   }

--- a/spec/classes/jdk_oracle_package_spec.rb
+++ b/spec/classes/jdk_oracle_package_spec.rb
@@ -7,9 +7,9 @@ describe 'jdk_oracle' do
     }}
   context 'with default values for all parameters' do
     it { should contain_jdk_oracle__install('jdk_oracle')}
-    it { is_expected.to contain_Archive('/opt/jdk-8u11-linux-x64.tar.gz')
-         .with_source('http://download.oracle.com/otn-pub/java/jdk/8u11-b12/jdk-8u11-linux-x64.tar.gz')
-         .with_extract_path('/opt/jdk1.8.0_11/..')
+    it { is_expected.to contain_Archive('/opt/jdk-8u121-linux-x64.tar.gz')
+         .with_source('http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz')
+         .with_extract_path('/opt/jdk1.8.0_121/..')
     }
 
     context 'with jce => true' do
@@ -18,22 +18,22 @@ describe 'jdk_oracle' do
       }}
       it { is_expected.to contain_Archive('/opt/jce_policy-8.zip')
                               .with_source('http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip')
-                              .with_extract_command('unzip -d /opt/jdk1.8.0_11/jre/lib/security -o -j %s')
+                              .with_extract_command('unzip -d /opt/jdk1.8.0_121/jre/lib/security -o -j %s')
       }
     end
     context 'with custom download url ' do
       let(:params) { {
           :download_url => 'http://onpremise_webhost/java'
       }}
-      it { is_expected.to contain_Archive('/opt/jdk-8u11-linux-x64.tar.gz')
-                              .with_source('http://onpremise_webhost/java/jdk/8u11-b12/jdk-8u11-linux-x64.tar.gz')
+      it { is_expected.to contain_Archive('/opt/jdk-8u121-linux-x64.tar.gz')
+                              .with_source('http://onpremise_webhost/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.tar.gz')
       }
     end
     context 'with proxy_host' do
       let(:params) { {
           :proxy_host => 'http://proxy_host:3128'
       }}
-      it { is_expected.to contain_Archive('/opt/jdk-8u11-linux-x64.tar.gz')
+      it { is_expected.to contain_Archive('/opt/jdk-8u121-linux-x64.tar.gz')
                               .with_proxy_server('http://proxy_host:3128')
       }
     end
@@ -41,8 +41,8 @@ describe 'jdk_oracle' do
       let(:params) { {
           :install_dir => '/path/to/installation/directory'
       }}
-      it { is_expected.to contain_Archive('/path/to/installation/directory/jdk-8u11-linux-x64.tar.gz')
-                              .with_extract_path('/path/to/installation/directory/jdk1.8.0_11/..')
+      it { is_expected.to contain_Archive('/path/to/installation/directory/jdk-8u121-linux-x64.tar.gz')
+                              .with_extract_path('/path/to/installation/directory/jdk1.8.0_121/..')
       }
     end
     context 'with build and update number' do


### PR DESCRIPTION
This overrides, extends and edges out #75.

Support for the hashes in newer Oracle 8 Download URLs.

Additionally, I've updated the default version to the most current version available. The local tests run fine, I don't know how to start the acceptance tests. They may be still failing because of the new defaults and the hash parameter.